### PR TITLE
Fix Vector2/3 set index accessors

### DIFF
--- a/3esCore/3esCore/Maths/Vector2.cs
+++ b/3esCore/3esCore/Maths/Vector2.cs
@@ -77,9 +77,8 @@ namespace Tes.Maths
         {
         case 0: X = value; break;
         case 1: Y = value; break;
-        default: break;
+        default: throw new IndexOutOfRangeException();
         }
-        throw new IndexOutOfRangeException();
       }
     }
 

--- a/3esCore/3esCore/Maths/Vector3.cs
+++ b/3esCore/3esCore/Maths/Vector3.cs
@@ -88,9 +88,8 @@ namespace Tes.Maths
         case 0: X = value; break;
         case 1: Y = value; break;
         case 2: Z = value; break;
-        default: break;
+        default: throw new IndexOutOfRangeException();
         }
-        throw new IndexOutOfRangeException();
       }
     }
 


### PR DESCRIPTION
Only throw IndexOutOfRangeException in Vector2/3 set index accessor when the index is out of range. Throw statement was in the wrong place and always executed.